### PR TITLE
Don't make cards copiable

### DIFF
--- a/src/cards/action_card.rs
+++ b/src/cards/action_card.rs
@@ -1,6 +1,8 @@
 use crate::cards::multi_color_card::RentCard;
 use std::{cmp::PartialEq, fmt, hash::Hash};
 
+use crate::game::{Playable, player::Player};
+
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub enum Action {
 	Birthday,
@@ -30,6 +32,12 @@ pub enum ActionCardKind {
 impl ActionCard {
 	pub fn new(value: u8, action: Action) -> Self {
 		Self { value, action }
+	}
+}
+
+impl Playable for ActionCardKind {
+	fn play(self, _player: &mut Player) {
+		println!("`Playable` yet to be implemented for `ActionCard`s");
 	}
 }
 

--- a/src/cards/action_card.rs
+++ b/src/cards/action_card.rs
@@ -1,7 +1,7 @@
 use crate::cards::multi_color_card::RentCard;
 use std::{cmp::PartialEq, fmt, hash::Hash};
 
-use crate::game::{Playable, player::Player};
+use crate::game::{player::Player, Playable};
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub enum Action {

--- a/src/cards/card.rs
+++ b/src/cards/card.rs
@@ -5,6 +5,7 @@ use crate::cards::{
 	Action, ActionCard, ActionCardKind, MoneyCard, PropertyCard, PropertyCardKind, RentVec,
 };
 use crate::color::{Color, MultiColor};
+use crate::game::{player::Player, Playable};
 
 #[derive(Debug, Hash, Eq, PartialEq)]
 pub enum Card {
@@ -43,6 +44,19 @@ impl Card {
 
 	pub fn new_property_wild_card(value: u8, colors: MultiColor) -> Self {
 		Self::Property(PropertyCardKind::Wild(PropertyWildCard::new(value, colors)))
+	}
+}
+
+
+impl Playable for Card {
+	fn play(self, player: &mut Player) {
+		match self {
+			Self::Bankable(b) => match b {
+				BankableCardKind::Money(_) => player.played.add_money(b),
+				BankableCardKind::Action(a) => a.play(player),
+			}
+			Self::Property(p) => p.play(player),
+		}
 	}
 }
 

--- a/src/cards/card.rs
+++ b/src/cards/card.rs
@@ -47,14 +47,13 @@ impl Card {
 	}
 }
 
-
 impl Playable for Card {
 	fn play(self, player: &mut Player) {
 		match self {
 			Self::Bankable(b) => match b {
 				BankableCardKind::Money(_) => player.played.add_money(b),
 				BankableCardKind::Action(a) => a.play(player),
-			}
+			},
 			Self::Property(p) => p.play(player),
 		}
 	}

--- a/src/cards/property_card.rs
+++ b/src/cards/property_card.rs
@@ -4,8 +4,11 @@ use std::{
 	hash::{Hash, Hasher},
 };
 
-use crate::{cards::{multi_color_card::PropertyWildCard, RentVec}, game::{player::Player, Playable}};
 use crate::color::{colored_text, Color};
+use crate::{
+	cards::{multi_color_card::PropertyWildCard, RentVec},
+	game::{player::Player, Playable},
+};
 
 #[derive(Debug, Eq)]
 pub struct PropertyCard {

--- a/src/cards/property_card.rs
+++ b/src/cards/property_card.rs
@@ -4,7 +4,7 @@ use std::{
 	hash::{Hash, Hasher},
 };
 
-use crate::cards::{multi_color_card::PropertyWildCard, RentVec};
+use crate::{cards::{multi_color_card::PropertyWildCard, RentVec}, game::{player::Player, Playable}};
 use crate::color::{colored_text, Color};
 
 #[derive(Debug, Eq)]
@@ -29,6 +29,12 @@ impl PropertyCard {
 			color,
 			rents,
 		}
+	}
+}
+
+impl Playable for PropertyCardKind {
+	fn play(self, player: &mut Player) {
+		player.played.add_property(self);
 	}
 }
 

--- a/src/game/game.rs
+++ b/src/game/game.rs
@@ -5,6 +5,10 @@ use crate::{
 
 use std::collections::VecDeque;
 
+pub trait Playable {
+	fn play(self, player: &mut Player);
+}
+
 #[derive(Debug)]
 pub struct Game {
 	draw_pile: Deck,
@@ -99,7 +103,7 @@ impl Game {
 
 		for pos in card_positions {
 			let selected_card = player.hand.remove(pos.into());
-			player.played.add(selected_card);
+			player.play(selected_card);
 		}
 	}
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -1,4 +1,4 @@
 mod game;
-mod player;
+pub mod player;
 
-pub use crate::game::game::Game;
+pub use crate::game::game::{Game, Playable};

--- a/src/game/player.rs
+++ b/src/game/player.rs
@@ -1,4 +1,5 @@
 use crate::cards::{BankableCardKind, Card, CardSet, PropertyCardKind};
+use crate::game::Playable;
 
 use std::collections::HashSet;
 use std::fmt;
@@ -33,11 +34,12 @@ impl Assets {
 		}
 	}
 
-	pub fn add(&mut self, card: Card) {
-		match card {
-			Card::Bankable(b) => self.bank.add(b),
-			Card::Property(p) => self.props.add(p),
-		};
+	pub fn add_money(&mut self, card: BankableCardKind) {
+		self.bank.add(card);
+	}
+
+	pub fn add_property(&mut self, card: PropertyCardKind) {
+		self.props.add(card);
 	}
 }
 
@@ -63,6 +65,10 @@ impl Player {
 		for card in cards {
 			self.hand.add(card);
 		}
+	}
+
+	pub fn play(&mut self, card: Card) {
+		card.play(self);
 	}
 
 	pub fn print_assets(&self) {


### PR DESCRIPTION
Implements `Playable` in such a way that it's not necessary for all card types to implement `Copy`.